### PR TITLE
Bump eslint to 4.18.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-flow": "^6.23.0",
-    "eslint": "^3.19.0",
+    "eslint": "^4.18.2",
     "eslint-plugin-flowtype": "^2.37.0",
     "eslint-plugin-import": "^2.2.0",
     "flow-bin": "^0.56.0",


### PR DESCRIPTION
Fixes vulnerability in eslint.

[1] https://github.com/eslint/eslint/commit/f6901d0bcf6c918ac4e5c6c7c4bddeb2cb715c09